### PR TITLE
feat: Implement Java Persistence API (JPA) for data laye

### DIFF
--- a/src/main/java/com/github/syann97/restful/myrestfulservice/bean/Post.java
+++ b/src/main/java/com/github/syann97/restful/myrestfulservice/bean/Post.java
@@ -1,0 +1,29 @@
+package com.github.syann97.restful.myrestfulservice.bean;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Post {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Integer id;
+
+	private String description;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JsonIgnore
+	private User user;
+}

--- a/src/main/java/com/github/syann97/restful/myrestfulservice/bean/User.java
+++ b/src/main/java/com/github/syann97/restful/myrestfulservice/bean/User.java
@@ -5,17 +5,27 @@ import java.util.Date;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 @JsonIgnoreProperties(value = {"password", "ssn"})
 @Schema(description = "사용자 상세 정보를 위한 도메인 객체")
+@Entity
+@Table(name = "user")
 public class User {
 	@Schema(title = "사용자 ID", description = "사용자 ID는 자동 생성")
+	@Id
+	@GeneratedValue
 	private Integer id;
 
 	@Schema(title = "사용자 이름", description = "사용자 이름 입력")

--- a/src/main/java/com/github/syann97/restful/myrestfulservice/bean/User.java
+++ b/src/main/java/com/github/syann97/restful/myrestfulservice/bean/User.java
@@ -1,6 +1,7 @@
 package com.github.syann97.restful.myrestfulservice.bean;
 
 import java.util.Date;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Size;
@@ -41,4 +43,15 @@ public class User {
 
 	@Schema(title = "사용자의 주민번호", description = "사용자의 주민번호 입력")
 	private String ssn;
+
+	@OneToMany(mappedBy = "user")
+	private List<Post> posts;
+
+	public User(Integer id, String name, Date joinDate, String password, String ssn) {
+		this.id = id;
+		this.name = name;
+		this.joinDate = joinDate;
+		this.password = password;
+		this.ssn = ssn;
+	}
 }

--- a/src/main/java/com/github/syann97/restful/myrestfulservice/config/SecurityConfig.java
+++ b/src/main/java/com/github/syann97/restful/myrestfulservice/config/SecurityConfig.java
@@ -2,11 +2,15 @@ package com.github.syann97.restful.myrestfulservice.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 
 @Configuration
 public class SecurityConfig {
@@ -27,5 +31,11 @@ public class SecurityConfig {
 	@Bean
 	BCryptPasswordEncoder passwordEncoder() {
 		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	protected SecurityFilterChain filterChain(HttpSecurity http, HandlerMappingIntrospector introspector) throws Exception {
+		http.csrf(AbstractHttpConfigurer::disable);
+		return http.build();
 	}
 }

--- a/src/main/java/com/github/syann97/restful/myrestfulservice/controller/UserJpaController.java
+++ b/src/main/java/com/github/syann97/restful/myrestfulservice/controller/UserJpaController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import com.github.syann97.restful.myrestfulservice.bean.Post;
 import com.github.syann97.restful.myrestfulservice.bean.User;
 import com.github.syann97.restful.myrestfulservice.exception.UserNotFoundException;
 import com.github.syann97.restful.myrestfulservice.repository.UserRepository;
@@ -77,5 +78,16 @@ public class UserJpaController {
 			.toUri();
 
 		return ResponseEntity.created(location).build();
+	}
+
+	@GetMapping("/users/{id}/posts")
+	public List<Post> retrieveAllPosts(@PathVariable int id) {
+		Optional<User> user = userRepository.findById(id);
+
+		if (user.isEmpty()) {
+			throw new UserNotFoundException("id = " + id);
+		}
+
+		return user.get().getPosts();
 	}
 }

--- a/src/main/java/com/github/syann97/restful/myrestfulservice/controller/UserJpaController.java
+++ b/src/main/java/com/github/syann97/restful/myrestfulservice/controller/UserJpaController.java
@@ -21,6 +21,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import com.github.syann97.restful.myrestfulservice.bean.Post;
 import com.github.syann97.restful.myrestfulservice.bean.User;
 import com.github.syann97.restful.myrestfulservice.exception.UserNotFoundException;
+import com.github.syann97.restful.myrestfulservice.repository.PostRepository;
 import com.github.syann97.restful.myrestfulservice.repository.UserRepository;
 
 import jakarta.validation.Valid;
@@ -30,9 +31,11 @@ import jakarta.validation.Valid;
 public class UserJpaController {
 
 	private UserRepository userRepository;
+	private PostRepository postRepository;
 
-	public UserJpaController(UserRepository userRepository) {
+	public UserJpaController(UserRepository userRepository, PostRepository postRepository) {
 		this.userRepository = userRepository;
+		this.postRepository = postRepository;
 	}
 
 	@GetMapping("/users")
@@ -89,5 +92,26 @@ public class UserJpaController {
 		}
 
 		return user.get().getPosts();
+	}
+
+	@PostMapping("/users/{id}/posts")
+	public ResponseEntity createPost(@PathVariable int id, @RequestBody Post post) {
+		Optional<User> userOptional = userRepository.findById(id);
+		if (userOptional.isEmpty()) {
+			throw new UserNotFoundException("id = " + id);
+		}
+
+		User user = userOptional.get();
+
+		post.setUser(user);
+
+		postRepository.save(post);
+
+		URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+			.path("/{id}")
+			.buildAndExpand(post.getId())
+			.toUri();
+
+		return ResponseEntity.created(location).build();
 	}
 }

--- a/src/main/java/com/github/syann97/restful/myrestfulservice/controller/UserJpaController.java
+++ b/src/main/java/com/github/syann97/restful/myrestfulservice/controller/UserJpaController.java
@@ -2,20 +2,27 @@ package com.github.syann97.restful.myrestfulservice.controller;
 
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.hateoas.EntityModel;
 import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import com.github.syann97.restful.myrestfulservice.bean.User;
 import com.github.syann97.restful.myrestfulservice.exception.UserNotFoundException;
 import com.github.syann97.restful.myrestfulservice.repository.UserRepository;
+
+import jakarta.validation.Valid;
 
 @RestController
 @RequestMapping("/jpa")
@@ -48,4 +55,27 @@ public class UserJpaController {
 		return ResponseEntity.ok(entityModel);
 	}
 
+
+	@DeleteMapping("/users/{id}")
+	public ResponseEntity<Void> deleteUserById(@PathVariable int id) {
+		Optional<User> user = userRepository.findById(id);
+		if (user.isEmpty()) {
+			throw new UserNotFoundException("id = " + id);
+		}
+		userRepository.delete(user.get());
+
+		return ResponseEntity.noContent().build();
+	}
+
+	@PostMapping("/users")
+	public ResponseEntity<User> createUser(@Valid @RequestBody User user) {
+		User savedUser = userRepository.save(user);
+
+		URI location = ServletUriComponentsBuilder.fromCurrentRequest()
+			.path("/{id}")
+			.buildAndExpand(savedUser.getId())
+			.toUri();
+
+		return ResponseEntity.created(location).build();
+	}
 }

--- a/src/main/java/com/github/syann97/restful/myrestfulservice/controller/UserJpaController.java
+++ b/src/main/java/com/github/syann97/restful/myrestfulservice/controller/UserJpaController.java
@@ -1,12 +1,20 @@
 package com.github.syann97.restful.myrestfulservice.controller;
 
-import java.util.List;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.*;
 
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.server.mvc.WebMvcLinkBuilder;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.github.syann97.restful.myrestfulservice.bean.User;
+import com.github.syann97.restful.myrestfulservice.exception.UserNotFoundException;
 import com.github.syann97.restful.myrestfulservice.repository.UserRepository;
 
 @RestController
@@ -20,8 +28,24 @@ public class UserJpaController {
 	}
 
 	@GetMapping("/users")
-	public List<User> getAllUsers() {
+	public List<User> retrieveAllUsers() {
 		return userRepository.findAll();
+	}
+
+	@GetMapping("/users/{id}")
+	public ResponseEntity<EntityModel> retrieveUserById(@PathVariable int id) {
+		Optional<User> user = userRepository.findById(id);
+
+		if (user.isEmpty()) {
+			throw new UserNotFoundException("id = " + id);
+		}
+
+		EntityModel entityModel = EntityModel.of(user.get());
+
+		WebMvcLinkBuilder linTo = linkTo(methodOn(this.getClass()).retrieveAllUsers());
+		entityModel.add(linTo.withRel("all-users"));
+
+		return ResponseEntity.ok(entityModel);
 	}
 
 }

--- a/src/main/java/com/github/syann97/restful/myrestfulservice/controller/UserJpaController.java
+++ b/src/main/java/com/github/syann97/restful/myrestfulservice/controller/UserJpaController.java
@@ -1,0 +1,27 @@
+package com.github.syann97.restful.myrestfulservice.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.github.syann97.restful.myrestfulservice.bean.User;
+import com.github.syann97.restful.myrestfulservice.repository.UserRepository;
+
+@RestController
+@RequestMapping("/jpa")
+public class UserJpaController {
+
+	private UserRepository userRepository;
+
+	public UserJpaController(UserRepository userRepository) {
+		this.userRepository = userRepository;
+	}
+
+	@GetMapping("/users")
+	public List<User> getAllUsers() {
+		return userRepository.findAll();
+	}
+
+}

--- a/src/main/java/com/github/syann97/restful/myrestfulservice/repository/PostRepository.java
+++ b/src/main/java/com/github/syann97/restful/myrestfulservice/repository/PostRepository.java
@@ -1,0 +1,9 @@
+package com.github.syann97.restful.myrestfulservice.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.github.syann97.restful.myrestfulservice.bean.Post;
+
+@Repository
+public interface PostRepository extends JpaRepository<Post, Integer> { }

--- a/src/main/java/com/github/syann97/restful/myrestfulservice/repository/UserRepository.java
+++ b/src/main/java/com/github/syann97/restful/myrestfulservice/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.github.syann97.restful.myrestfulservice.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.github.syann97.restful.myrestfulservice.bean.User;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Integer> {
+}


### PR DESCRIPTION
### 작업 내용
- [x] Add JPA dependency and configure User entity
- [x] Initialize data with Spring Data JPA
- [x] Implement JPA service with Controller and Repository
- [x] Add GET method to retrieve a single user
- [x] Add POST and DELETE methods for user management
- [x] Add Post entity and initial data
- [x] Configure one-to-many relationship between User and Post
- [x] Add POST method for creating new posts

### 관련 이슈
Closes #29